### PR TITLE
MM 65 answer correct/incorrect hover color added

### DIFF
--- a/src/components/quiz/Answer.scss
+++ b/src/components/quiz/Answer.scss
@@ -6,10 +6,16 @@
 
     &--correct {
       background-color: $button-dashboard-green;
+      &:hover {
+        background-color: $button-dashboard-green;
+      }
     }
 
     &--incorrect {
       background-color: $header-font-color;
+      &:hover {
+        background-color: $header-font-color;
+      }
     }
   }
 }


### PR DESCRIPTION
Button component has hover effect which prevented correct / incorrect answer feedback colour (red/green) showing to user.
Made the hover colour the correct / incorrect colour so if the user is hovering over the button they still see the feedback colour